### PR TITLE
Improve asset detection

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -70,9 +70,7 @@ def extract_archive(item_path, is_debug_mode):
 def clean_folder(folder_path):
     for item_path in pathlib.Path(folder_path).iterdir():
         item = item_path.name
-        if item_path.is_dir() and item not in target_folders:
-            shutil.rmtree(item_path)
-        elif item_path.is_file():
+        if item_path.is_file():
             item_path.unlink()
 
 def add_to_database(root_path, item):
@@ -94,8 +92,9 @@ def add_to_database(root_path, item):
 
 
 # Searching the content of extracted archive for target folders
-def traverse_directory(folder_path, current_item, progressbar, is_debug_mode):
+def traverse_directory(folder_path, current_item, progressbar, is_debug_mode, is_nested_archive = False):
     archive_extracted = False
+    manifest_exists = False
     for root, dirs, files in pathlib.Path(folder_path).walk():
         for file in files:
             if file.lower().endswith(('.zip', '.rar', '7z', '.tar')):
@@ -106,10 +105,22 @@ def traverse_directory(folder_path, current_item, progressbar, is_debug_mode):
                 time.sleep(0.5)
                 pathlib.Path(root).joinpath(file).unlink()
                 archive_extracted = True
+            if file.lower().endswith("manifest.dsx"):
+                manifest_exists = True
+
         progressbar.set(progressbar.get() + 0.1)
         if archive_extracted:
             progressbar.set(progressbar.get()+0.1)
-            return traverse_directory(folder_path, current_item, progressbar,  is_debug_mode)
+            is_nested_archive = archive_extracted
+            return traverse_directory(folder_path, current_item, progressbar,  is_debug_mode, is_nested_archive)
+        if manifest_exists:
+            content_path = pathlib.Path(str(root)).joinpath(dirs[0])
+            progressbar.set(0.9)
+            clean_folder(content_path)
+            if add_to_database(content_path, current_item):
+                return False
+            shutil.copytree(content_path, get_library_path(), dirs_exist_ok=True)
+            return True
         if any(target in dirs for target in target_folders):
             progressbar.set(0.9)
             clean_folder(root)

--- a/installer.py
+++ b/installer.py
@@ -114,13 +114,15 @@ def traverse_directory(folder_path, current_item, progressbar, is_debug_mode, is
             is_nested_archive = archive_extracted
             return traverse_directory(folder_path, current_item, progressbar,  is_debug_mode, is_nested_archive)
         if manifest_exists:
-            content_path = pathlib.Path(str(root)).joinpath(dirs[0])
-            progressbar.set(0.9)
-            clean_folder(content_path)
-            if add_to_database(content_path, current_item):
-                return False
-            shutil.copytree(content_path, get_library_path(), dirs_exist_ok=True)
-            return True
+            for folder in dirs:
+                if folder.lower().startswith("content"):
+                    content_path = pathlib.Path(str(root)).joinpath(folder)
+                    progressbar.set(0.9)
+                    clean_folder(content_path)
+                    if add_to_database(content_path, current_item):
+                        return False
+                    shutil.copytree(content_path, get_library_path(), dirs_exist_ok=True)
+                    return True
         if any(target in dirs for target in target_folders):
             progressbar.set(0.9)
             clean_folder(root)


### PR DESCRIPTION
Explained in issue: https://github.com/Ati1707/DazContentInstaller/issues/24

TDLR: Before this PR the tool only imported folders that are defined in a list. Now it imports any folder if either the manifest file exists or if one of the target folders exist. If none of them exists the user need to manually import the asset.
```
target_folders = [
    "aniBlocks", "data", "Environments", "Light Presets", "People",
    "Props", "ReadMe's", "Render Presets", "Render Settings", "Runtime",
    "Scenes", "Scripts", "Shader Presets", "Cameras", "Documentation"
]
```